### PR TITLE
Change type of size to ScmSmallInt for newer Gauche versions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-04-23  Fabian Brosda <fabi3141@gmx.de>
+
+	* dbd_pglib.stub (pg-escape-string): Also make it work for
+          GAUCHE_API_VERSION 97 and newer.
+
 2018-11-30  Shiro Kawai  <shiro@acm.org>
 
 	* dbd_pglib.stub (pg-escape-string): Make it work for both

--- a/dbd_pglib.stub
+++ b/dbd_pglib.stub
@@ -128,7 +128,9 @@
 ;; of the string if we have MB string.  I wrote this assuming they meant the
 ;; number of bytes.  --[SK]
 (define-cproc pq-escape-string (str::<string>)
-  (body "#if GAUCHE_API_0_95"
+  (body "#if GAUCHE_API_0_97 || GAUCHE_API_VERSION >= 97"
+        "ScmSmallInt size, rsize;"
+        "#elif GAUCHE_API_0_95"
         "ScmSize size, rsize;"
         "#else"
         "u_int size, rsize;"


### PR DESCRIPTION
The type of the `size` parameter of `Scm_GetStringContent` changed from `u_int` to `ScmSmallInt` in https://github.com/shirok/Gauche/commit/a89f52d6b72cdf4c6ca39ef16c2383516d22460f. Therefore adust the parameter type in `pg-escape-string` for api version 97 and newer.